### PR TITLE
Add empty activationEvents to manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,6 @@
     "mocha": "^10.2.0",
     "typescript": "^5.1.6",
     "@vscode/test-electron": "^2.3.4"
-  }
+  },
+  "activationEvents": []
 }


### PR DESCRIPTION
This fixes the vsce error encountered in https://github.com/argumentcomputer/lurk-vscode/issues/8 when following the instructions in the README. See my previous comment for rationale: https://github.com/argumentcomputer/lurk-vscode/issues/8#issuecomment-2458388411