### PR TITLE
fix: improve regexes to match on built-in symbols

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,23 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
+// Import the 'vscode' module to use the VS Code extensibility API
 import * as vscode from 'vscode';
 
+// Define a unique name for the Lurk REPL terminal
 const lurkTerminalName = 'Lurk REPL';
 
+// Store a reference to the Lurk REPL terminal (if it has been created)
 let lurkTerminal: vscode.Terminal | null = null;
 
+/**
+ * Gets or creates the Lurk REPL terminal instance.
+ *
+ * If the terminal doesn't exist, or if it was closed (determined by checking
+ * the `exitStatus` property), this function creates a new terminal with settings
+ * based on the 'lurkREPL' configuration.
+ *
+ * @returns {vscode.Terminal} The active or newly created Lurk REPL terminal instance.
+ */
 function getTerminal(): vscode.Terminal {
-    // create lurk terminal if it doesn't exist
+    // Create the Lurk terminal if it doesn't already exist or if it was closed.
     if (lurkTerminal === null || lurkTerminal.exitStatus !== undefined) {
         const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('lurkREPL');
         const lurkCommand = config.get("lurkRunCommand", "${userHome}/.cargo/bin/lurk");
@@ -24,8 +34,15 @@ function getTerminal(): vscode.Terminal {
     return lurkTerminal;
 }
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+/**
+ * When the extension is activated, it registers two commands:
+ *   - `lurkREPL.start`: Initializes the Lurk REPL terminal.
+ *   - `lurkREPL.sendSelected`: Sends the currently selected text in the editor
+ *     to the Lurk REPL terminal for evaluation.
+ *
+ * @param {vscode.ExtensionContext} context - The extension context for managing resources
+ *   and subscriptions.
+ */
 export function activate(context: vscode.ExtensionContext) {
     function start () {
         getTerminal();

--- a/syntaxes/lurk.tmLanguage.json
+++ b/syntaxes/lurk.tmLanguage.json
@@ -1,73 +1,69 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "lurk",
-	"foldingStartMarker": "\\(",
-	"foldingStopMarker": "\\)",
-	"patterns": [
-		{ "include": "#comment" },	
-		{ "include": "#builtin" },
-		{ "include": "#meta" },
-		{ "include": "#string" },
-		{ "include": "#char" }
-	],
-	"repository": {
-		"comment": {
-			"begin": "(^[ \\t]+)?(?=;)",
-			"beginCaptures": {
-			  "1": {
-				"name": "punctuation.whitespace.comment.leading"
-			  }
-			},
-			"end": "(?!\\G)",
-			"patterns": [
-			  {
-				"begin": ";",
-				"beginCaptures": {
-				  "0": {
-					"name": "punctuation.definition.comment"
-				  }
-				},
-				"end": "\\n",
-				"name": "comment.line.semicolon"
-			  }
-			]
-		  },
-		"builtin": {
-			"patterns": [
-			  {
-			    "name": "keyword.control",
-				"match": "(?<=[(\\s])\\b(atom|begin|car|cdr|char|commit|comm|bignum|cons|current-env|emit|empty-env|eval|eq|type-eq|type-eqq|hide|if|lambda|let|letrec|nil|u64|open|quote|secret|strcons|t|breakpoint)\\b"
-			  },
-			  {
-			    "name": "keyword.control",
-				"match": "(?<=[(\\s])([+-/<>=%\\\\*]|<=|>=)(?=[)\\s])"
-			  }
-			]
-		},
-		"meta": {
-			"patterns": [
-			  {
-				"name": "keyword.other",
-				"begin": "!\\(\\s*",
-				"end": "(\\s|\\))"
-			  }
-			]
-		},
-		"string": {
-			"name": "string.quoted.double",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape",
-					"match": "\\\\."
-				}
-			]
-		},
-		"char": {
-			"name": "constant.character",
-			"match": "'\\\\?.'"
-		}
-	},
-	"scopeName": "source.lurk"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "lurk",
+  "foldingStartMarker": "\\(",
+  "foldingStopMarker": "\\)",
+  "patterns": [
+    { "include": "#comment" },
+    { "include": "#builtin" },
+    { "include": "#meta" },
+    { "include": "#string" },
+    { "include": "#char" }
+  ],
+  "repository": {
+    "comment": {
+      "begin": "(^[ \\t]+)?(?=;)",
+      "beginCaptures": { "1": { "name": "punctuation.whitespace.comment.leading" } },
+      "end": "(?!\\G)",
+      "patterns": [
+        {
+          "begin": ";",
+          "beginCaptures": { "0": { "name": "punctuation.definition.comment" } },
+          "end": "\\n",
+          "name": "comment.line.semicolon"
+        }
+      ]
+    },
+    "builtin": {
+      "patterns": [
+        {
+          "name": "keyword.control",
+          "match": "(?<=[(\\s])(?:nil|t|&rest)(?=[)\\s])"
+        },
+        {
+          "name": "keyword.control",
+          "match": "(?<=[(\\s])\\b(atom|apply|begin|car|cdr|char|commit|comm|bignum|cons|current-env|emit|empty-env|eval|eq|eqq|type-eq|type-eqq|hide|if|lambda|let|letrec|u64|open|quote|secret|strcons|list|breakpoint|fail)\\b(?=[)\\s])"
+        },
+        {
+          "name": "keyword.control",
+          "match": "(?<=[(\\s])([+-/<>=%\\\\*]|<=|>=)(?=[)\\s])"
+        }
+      ]
+    },
+    "meta": {
+      "patterns": [
+        {
+          "name": "keyword.other",
+          "begin": "!\\(\\s*",
+          "end": "(\\s|\\))"
+        }
+      ]
+    },
+    "string": {
+      "name": "string.quoted.double",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "char": {
+      "name": "constant.character",
+      "match": "'\\\\?.'"
+    }
+  },
+  "scopeName": "source.lurk"
 }


### PR DESCRIPTION
* Fix the matching of `<built-in>` in `<built-in>-foo`
* Do the same for `nil` and `t`
* Include `&rest` to be matched on as a symbol in the `.lurk` package
* Include new built-ins such as `apply` and `fail`

Extra:
* Shorten JSON formatting for `syntaxes/lurk.tmLanguage.json`
* Improve documentation for `src/extension.ts`